### PR TITLE
Fix the movies endpoints test

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+ENV['RACK_ENV'] = 'test'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
The problem
=========
Even when the endpoint returned a 500 error, the movies endpoint tests returned true.
Why, because the rack env was set to development, and in development mode, the html returned by the api in case of failure is a full description of the error and the backtrace.
So we were checking if 'The Gold Rush' was included in "\<html\>..Description, backtrace...... Expected ..... to include 'The Gold Rush' ......\<...\>"

The solution
=======
One line 😉 

![image](https://i.giphy.com/media/3oEduO4hD4KjTLlj2g/giphy.webp)
